### PR TITLE
Introduce params argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ On the other hand in the fail step, we can match the aggregate data since no par
 
 ```
 
-## Comparison to `with`
+## Why use Q?
 
-A major benefit of using ExQ over `with` is that the results of all steps before an error are available and the step which produced the error is also easily identifiable.
+A major benefit of using ExQ is that the results of all steps before an error are available and the step which produced the error is also easily identifiable.
+
+Compare the following two snippets:
 
 ```elixir
   user_id = 1234

--- a/lib/q.ex
+++ b/lib/q.ex
@@ -9,7 +9,7 @@ defmodule Q do
   defstruct operations: [], names: MapSet.new()
   @type t :: %__MODULE__{operations: operations, names: names}
   @type state :: map
-  @type fun_arity1 :: ((state) -> {:ok | :error | :halt, any})
+  @type fun_arity1 :: (state -> {:ok | :error | :halt, any})
   @type fun_mfa :: {module, atom, [any]}
   @typep operation :: {:run, fun} | {:put, any} | {:inspect, Keyword.t()}
   @typep operations :: [{name, operation}]
@@ -165,7 +165,7 @@ defmodule Q do
   end
 
   def run(que, name, {mod, fun}, params)
-  when is_atom(mod) and is_atom(fun) do
+      when is_atom(mod) and is_atom(fun) do
     run(que, name, {mod, fun, []}, params)
   end
 

--- a/lib/q.ex
+++ b/lib/q.ex
@@ -17,7 +17,10 @@ defmodule Q do
   @type exec_error :: {:error, name, any, list}
 
   @doc """
-  Returns an empty `Q` struct.
+  Creates and returns a new, empty `Q` struct.
+
+  The resulting queue can be used as a starting point for queue operations,
+  such as `put/3` and `run/4`.
 
   ## Example
       iex> Q.new() |> Q.to_list()
@@ -30,21 +33,39 @@ defmodule Q do
 
   @doc """
   Adds a value to the changes so far under the given name.
+
+  This function modifies the queue by associating the given `name` with a `value`.
+  If the operation is successful, the `name` will become a key in the queue's internal
+  state map, and `value` will be its associated value.
+
+  ## Params
+
+  - `que`: The queue to add the value to.
+  - `name`: The name to associate with the value. It must be unique, or an error will be raised.
+  - `value`: The value to add to the queue.
+
+  ## Errors
+
+  This function will raise an error if `name` is already present in the queue.
+
   ## Example
-      Q.new()
-      |> Q.put(:params, params)
-      |> Q.run()
+      iex> Q.new()
+      ...> |> Q.put(:params, %{foo: "bar"})
+      ...> |> Q.exec()
+
+      {:ok, %{params: %{foo: "bar"}}}
   """
   @spec put(t, name, any) :: t
   def put(que, name, value) do
-    add_operation(que, name, {:put, value})
+    add_operation(que, name, {:put, value}, [])
   end
 
   @doc """
-  Returns the list of operations stored in the queue.
-  Always use this function when you need to access the operations you
-  have defined in `Q`. Inspecting the `Q` struct internals
-  directly is discouraged.
+  Converts the operations queue to a list, in the order they were added.
+
+  This function is useful for inspecting the current state of the queue.
+  Direct inspection of the queue's internal state is discouraged to maintain
+  encapsulation.
   """
   @spec to_list(t) :: [{name, term}]
   def to_list(%Q{operations: operations}) do
@@ -52,18 +73,57 @@ defmodule Q do
     |> Enum.reverse()
   end
 
+  @doc """
+  Returns a list of operation names stored in the queue, in the order they were added.
+
+  This function can be used to review the sequence of operations added to the queue.
+
+
+  ## Example
+      iex> Q.new()
+      ...> |> Q.put(:init, "foo")
+      ...> |> Q.run(:test, fn text -> {:ok, text} end, [:init])
+      ...> |> Q.operations()
+
+      ["test", "init"]
+  """
+  @spec operations(Q.t()) :: list
+  def operations(%Q{operations: operations}) do
+    operations
+    |> Enum.map(fn {op_name, _} -> op_name end)
+    |> Enum.reverse()
+  end
+
+  @doc """
+  Adds an operation to the queue that, when executed, prints the current state of the queue.
+
+  The printing is performed using Elixir's `IO.inspect/2`, which provides a human-readable
+  representation of the queue's state.
+
+  ## Params
+
+  - `que`: The queue to inspect.
+  - `opts`: Options passed to `IO.inspect/2`. If the `:only` option is provided, only those keys will be printed.
+
+  """
   @spec inspect(t, Keyword.t()) :: t
   def inspect(que, opts \\ []) do
     Map.update!(que, :operations, &[{:inspect, {:inspect, opts}} | &1])
   end
 
   @doc """
-  Executes the queue.
+  Executes the queue, running all operations in the order they were added.
+
+  Each operation is provided with the state of the queue as of the start of the operation.
+  If an operation function returns an error, the execution of the queue is halted and an error is returned.
+
 
   ## Example
-      Q.new()
-      |> Q.run(:write, fn _, _ -> {:ok, nil} end)
-      |> Q.exec()
+      iex> Q.new()
+      ...> |> Q.run(:write, fn _ -> {:ok, "Hello world!"} end)
+      ...> |> Q.exec()
+
+      {:ok, %{write: "Hello world!"}}
   """
   @spec exec(t) :: {:ok, term} | exec_error
   def exec(%Q{} = que) do
@@ -76,25 +136,35 @@ defmodule Q do
   end
 
   @doc """
-  Adds a function to run as part of the queue.
-  The function should return either `{:ok, value}` or `{:error, value}`.
-  Receives the changes so far as its argument (prepended to those passed in the call to the function).
+  Adds a function to be executed as part of the queue.
 
-  ## Example
-      Q.run(multi, :write, fn %{image: image} ->
-        with :ok <- File.write(image.name, image.contents) do
-          {:ok, nil}
-        end
-      end)
+  This function enables adding operations to the queue that are executed when `exec/1` is called.
+  The operations can be anonymous functions or functions in a module.
+
+  The function should return either `{:ok, value}` if the operation was successful or
+  `{:error, value}` if the operation failed. The state of the queue is passed
+  as arguments to the function if no params are specified.
+
+  Functions can additionally return {:halt, value} to halt execution early.
+
+  ## Params
+
+  - `que`: The queue to which the function should be added.
+  - `name`: A unique name for this operation. It will be used as a key in the queue's internal state.
+  - `run`: The function to be run. It can be an anonymous function or a tuple containing a module, function, and arguments.
+  - `params` (optional): A list of keys in the queue's internal state that should be passed to the function as arguments.
+
   """
-  @spec run(t, name, run) :: t
-  def run(que, name, {mod, fun, args} = run)
+  @spec run(t, name, run, [atom]) :: t
+  def run(que, name, run, params \\ [])
+
+  def run(que, name, {mod, fun, args} = _run, params)
       when is_atom(mod) and is_atom(fun) and is_list(args) do
-    add_operation(que, name, {:run, run})
+    add_operation(que, name, {:run, {mod, fun, args, params}}, params)
   end
 
-  def run(que, name, run) when is_function(run) do
-    add_operation(que, name, {:run, run})
+  def run(que, name, run, params) when is_function(run) do
+    add_operation(que, name, {:run, {run, params}}, params)
   end
 
   @doc """
@@ -102,15 +172,26 @@ defmodule Q do
   Similar to `run/3`, but allows to pass module name, function and arguments.
   The function should return either `{:ok, value}` or `{:error, value}`.
   Receives the changes so far as its argument (prepended to those passed in the call to the function).
+
+  ## Params
+
+  - `que`: The queue to which the function should be added.
+  - `name`: A unique name for this operation. It will be used as a key in the queue's internal state.
+  - `mod`: The module where the function is defined.
+  - `fun`: The function to be executed.
+  - `args`: Arguments that should be passed to the function.
+  - `params` (optional): A list of keys in the queue's internal state that should be passed to the function as arguments.
   """
-  @spec run(t, name, module, function, args) :: t when function: atom, args: [any]
-  def run(que, name, mod, fun, args)
+  @deprecated "Use run/4 instead"
+  @spec run(t, name, module, function, args, [atom]) :: t when function: atom, args: [any]
+  def run(que, name, mod, fun, args, params \\ [])
       when is_atom(mod) and is_atom(fun) and is_list(args) do
-    add_operation(que, name, {:run, {mod, fun, args}})
+    add_operation(que, name, {:run, {mod, fun, args, params}}, params)
   end
 
-  defp add_operation(%Q{} = que, name, operation) do
+  defp add_operation(%Q{} = que, name, operation, params) do
     %{operations: operations, names: names} = que
+    check_params_existence(names, params)
 
     if MapSet.member?(names, name) do
       raise "#{Kernel.inspect(name)} is already a member of the Q: \n#{Kernel.inspect(que)}"
@@ -139,10 +220,10 @@ defmodule Q do
   end
 
   defp apply_operation({name, operation}, {acc, names}) do
-    case apply_operation(operation, acc) do
-      {:ok, value} ->
-        {:cont, {Map.put(acc, name, value), names}}
-
+    with {:ok, value} <- apply_operation(operation, acc),
+         acc <- Map.put(acc, name, value) do
+      {:cont, {acc, names}}
+    else
       {:halt, value} ->
         {:halt, {Map.put(acc, name, value), names}}
 
@@ -160,9 +241,30 @@ defmodule Q do
   defp apply_operation({:put, value}, _acc),
     do: {:ok, value}
 
-  defp apply_run_fun({mod, fun, args}, acc) do
-    apply(mod, fun, [acc | args])
+  defp apply_run_fun({mod, fun, args, params}, acc) do
+    apply(mod, fun, build_args(acc, params, args))
   end
 
-  defp apply_run_fun(fun, acc), do: fun.(acc)
+  defp apply_run_fun({fun, params}, acc) when is_function(fun) do
+    apply(fun, build_args(acc, params, []))
+  end
+
+  defp build_args(acc, params, rest_args) do
+    case params do
+      [] -> [acc | rest_args]
+      _ -> Enum.map(params, fn key -> Map.get(acc, key) end) ++ rest_args
+    end
+  end
+
+  defp check_params_existence(_names, []), do: :ok
+
+  defp check_params_existence(names, params) do
+    for param <- params do
+      unless MapSet.member?(names, param) do
+        raise "The parameter #{Kernel.inspect(param)} does not exist in the queue."
+      end
+    end
+
+    :ok
+  end
 end

--- a/lib/q.ex
+++ b/lib/q.ex
@@ -145,7 +145,7 @@ defmodule Q do
   `{:error, value}` if the operation failed. The state of the queue is passed
   as arguments to the function if no params are specified.
 
-  Functions can additionally return {:halt, value} to halt execution early.
+  Functions can also return {:halt, value} to halt execution at any point.
 
   ## Params
 
@@ -168,10 +168,14 @@ defmodule Q do
   end
 
   @doc """
-  Adds a function to run as part of the queue.
-  Similar to `run/3`, but allows to pass module name, function and arguments.
-  The function should return either `{:ok, value}` or `{:error, value}`.
-  Receives the changes so far as its argument (prepended to those passed in the call to the function).
+  Adds a function to be executed as part of the queue.
+  Similar to `run/4`, but allows to pass module name, function and arguments.
+
+  The function should return either `{:ok, value}` if the operation was successful or
+  `{:error, value}` if the operation failed. The state of the queue is passed
+  as arguments to the function if no params are specified.
+
+  Functions can also return {:halt, value} to halt execution at any point.
 
   ## Params
 
@@ -182,7 +186,6 @@ defmodule Q do
   - `args`: Arguments that should be passed to the function.
   - `params` (optional): A list of keys in the queue's internal state that should be passed to the function as arguments.
   """
-  @deprecated "Use run/4 instead"
   @spec run(t, name, module, function, args, [atom]) :: t when function: atom, args: [any]
   def run(que, name, mod, fun, args, params \\ [])
       when is_atom(mod) and is_atom(fun) and is_list(args) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Q.MixProject do
   use Mix.Project
 
   @name "ExQ"
-  @version "1.0.0"
+  @version "1.1.0"
   @url "https://github.com/gpedic/ex_q"
 
   def project do

--- a/test/q_test.exs
+++ b/test/q_test.exs
@@ -106,7 +106,7 @@ defmodule QTest do
         Q.new()
         |> Q.run(:read2, fn _ -> {:ok, "hello world"} end)
         |> Q.run(:write, fn text -> {:ok, text} end, [:read2])
-        |> Q.run(:write2, {TestWriter, :write, [upcase: true]}, [:read2])
+        |> Q.run(:write2, {TestWriter, :write, [[upcase: true]]}, [:read2])
         |> Q.run(:write3, &TestWriter.write/1, [:read2])
         |> Q.exec()
 

--- a/test/q_test.exs
+++ b/test/q_test.exs
@@ -101,6 +101,20 @@ defmodule QTest do
               }} = result
     end
 
+    test "when using a 2 element tuple args default to []" do
+      result =
+        Q.new()
+        |> Q.put(:init, "hello world")
+        |> Q.run(:write, {TestWriter, :write}, [:init])
+        |> Q.exec()
+
+      assert {:ok,
+              %{
+                init: "hello world",
+                write: "hello world"
+              }} = result
+    end
+
     test "the only the requested params are passed" do
       result =
         Q.new()

--- a/test/q_test.exs
+++ b/test/q_test.exs
@@ -18,7 +18,6 @@ defmodule QTest do
 
     def write(text, opts) do
       upcase = Keyword.get(opts, :upcase, false)
-      IO.inspect(opts)
 
       if upcase do
         {:ok, String.upcase(text)}


### PR DESCRIPTION
Allow the definition of params which should be passed to the function run. This allows for simpler use of functions not specifically created for use with the data structure passed by Q.

See readme for examples